### PR TITLE
Added box as collision in  mobile_base_body_link

### DIFF
--- a/urdf/creo2urdf/data/R1Mk3/base_1_0.yaml
+++ b/urdf/creo2urdf/data/R1Mk3/base_1_0.yaml
@@ -874,6 +874,11 @@ assignedCollisionGeometry:
        radius: 0.16
        length: 0.005
        origin: [0.0,-0.03,0.0,1.57079632679,0.0,0.0]
+   - linkName: mobile_base_body_link
+     geometricShape:
+       shape: box
+       size: 0.32
+       origin: [0.0,0.0,0.0,0.0,0.0,0.0]
 
 XMLBlobs:
     - |


### PR DESCRIPTION
Added a box shape to replace a complex mesh in mobile base body link.
This should fix instability of collision with the ground when using DART engine (gz sim) 