### PR TITLE
Added namespaces to ros2 nws

### DIFF
--- a/urdf/R1Mk3/conf/gazebo_cer_odometry/gazebo_cer_odometry_nws_ros2.xml
+++ b/urdf/R1Mk3/conf/gazebo_cer_odometry/gazebo_cer_odometry_nws_ros2.xml
@@ -2,10 +2,11 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cer_odometry_nws_ros2" type="odometry2D_nws_ros2">
-    <param name="topic_name">   /odometry </param>
-    <param name="node_name">    cer_odometry_nws_ros2 </param>
-    <param name="base_frame">   mobile_base_body_link </param>
-    <param name="odom_frame">   odom </param>
+    <param name="namespace">    ${portprefixnoslash}    </param>
+    <param name="node_name">    cer_odometry_nws_ros2   </param>
+    <param name="topic_name">   ${portprefix}/odometry  </param>
+    <param name="base_frame">   ${portprefixnoslash}/mobile_base_body_link </param>
+    <param name="odom_frame">   ${portprefixnoslash}/odom </param>
     
     <action phase="startup" level="10" type="attach">
             <param name="device">  cer_odometry </param>

--- a/urdf/R1Mk3/conf/wrappers/motorControl/alljoints_ros2_wrapper.xml
+++ b/urdf/R1Mk3/conf/wrappers/motorControl/alljoints_ros2_wrapper.xml
@@ -4,7 +4,8 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cbw_ros2" type="controlBoard_nws_ros2">
     <param name="node_name"> ros2_cb_node </param>
     <param extern-name="cbw_ros2_msgs_name" name="msgs_name"> ros2_cb_msgs </param>
-    <param name="topic_name"> /joint_states </param>
+    <param name="topic_name"> ${portprefix}/joint_states </param>
+    <param name="namespace">  ${portprefixnoslash}    </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> cer_all_joints_mc_remapper </param>
     </action>

--- a/urdf/R1Mk3/conf/wrappers/sensors/lidar_double_nws_ros2.xml
+++ b/urdf/R1Mk3/conf/wrappers/sensors/lidar_double_nws_ros2.xml
@@ -2,9 +2,10 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapROS2" type="rangefinder2D_nws_ros2">
     <param name="period"> 0.01 </param>
+    <param name="namespace">    ${portprefixnoslash}    </param>
     <param name="node_name">    rangefinder_ros2_node    </param>
-    <param name="topic_name">   /laser   </param>
-    <param name="frame_id">    mobile_base_double_lidar   </param>
+    <param name="topic_name">   ${portprefix}/laser   </param>
+    <param name="frame_id">     ${portprefixnoslash}/mobile_base_double_lidar   </param>
     <action phase="startup" level="10" type="attach">
         <paramlist name="networks">
             <elem name="cer_laser"> laser_double  </elem>

--- a/urdf/R1Mk3/conf/wrappers/sensors/rgbd_camera_nws_ros2.xml
+++ b/urdf/R1Mk3/conf/wrappers/sensors/rgbd_camera_nws_ros2.xml
@@ -4,11 +4,12 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="depthWrapY" type="rgbdSensor_nws_ros2">
     <param name="period">0.033</param>
-    <param name="color_topic_name"> /camera_rgbd/color/image_rect_color </param>
-    <param name="depth_topic_name"> /camera_rgbd/depth/image_rect </param>
-    <param name="color_frame_id"> depth_center </param>
-    <param name="depth_frame_id"> depth_center </param>
-    <param name="node_name"> rgbdsensor_ros_node </param>
+    <param name="namespace">        ${portprefixnoslash}    </param>
+    <param name="color_topic_name"> ${portprefix}/camera_rgbd/color/image_rect_color </param>
+    <param name="depth_topic_name"> ${portprefix}/camera_rgbd/depth/image_rect </param>
+    <param name="color_frame_id">   ${portprefixnoslash}/depth_center </param>
+    <param name="depth_frame_id">   ${portprefixnoslash}/depth_center </param>
+    <param name="node_name">        rgbdsensor_ros_node </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="the_device"> depthcamera_plugin_device </elem>


### PR DESCRIPTION
This PR adds namespaces to all topics and tfs published on ROS2, allowing the simulation of multiple robots inside gazebo.

> [!WARNING]  
Beware: this is a breaking change and some topic names must be fixed on the application side.

For example, the cameras will become:
```
/camera_rgbd/color/image_rect_color - > r1mk3sim/camera_rgbd/color/image_rect_color 
```

Also the robot_state_publisher must subscribe to:
```
${portprefix}/joint_states 
```

${portprefix} will also appear at the beginning of the frame names in the `tf` topic.

> [!WARNING]  
Chatgpt note:

<img width="1407" height="820" alt="image" src="https://github.com/user-attachments/assets/106458ca-abe6-404d-9935-8631cd65b2c7" />
