### PR TITLE
Enable C++ language support in CMakeLists only for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 
 project(r1-models
-        VERSION 1.0.1)
+        VERSION 1.0.1
+        LANGUAGES NONE)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -20,9 +21,9 @@ if(COMPILE_R1Mk3Models)
    add_subdirectory(urdf)
 endif()
 
-if (BUILD_TESTING)
+if(BUILD_TESTING)
+  enable_language(CXX)
   include(CTest)
-  enable_testing()
   add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
Added support for C++ language in the project configuration only when the unit tests are enablesd.